### PR TITLE
fall back on bignum implementation when grisu3 fails

### DIFF
--- a/src/bignum.c
+++ b/src/bignum.c
@@ -1,0 +1,812 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) 2010, the V8 project authors.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "bignum.h"
+#include "utils.h"
+
+// 3584 = 128 * 28. We can represent 2^3584 > 10^1000 accurately.
+// This bignum can encode much bigger numbers, since it contains an
+// exponent.
+const int kBigNumMaxSignificantBits = 3584;
+
+// With bigit size of 28 we loose some bits, but a double still fits easily
+// into two chunks, and more importantly we can use the Comba multiplication.
+const int kBigitSize = 28;
+const Chunk kBigitMask = 268435455; // (1 << kBigitSize) - 1;
+// Every instance allocates kBigitLength chunks on the stack. Bignums cannot
+// grow. There are no checks if the stack-allocated space is sufficient.
+const int kBigitCapacity = 128; // kBigNumMaxSignificantBits / kBigitSize;
+
+
+static const int kBigNumChunkSize = sizeof(Chunk) * 8;
+static const int kBigNumDoubleChunkSize = sizeof(DoubleChunk) * 8;
+
+bignum new_bignum() {
+  bignum num;
+  num.used_digits = 0;
+  num.exponent = 0;
+  for (int i = 0; i < kBigitCapacity; ++i) {
+    num.bigits[i] = 0;
+  }
+  return num;
+}
+
+
+static int uint16_bit_size(uint16_t value) {
+  return 8 * sizeof(value);
+}
+
+static int max_int(int a, int b) {
+  return a < b ? b : a;
+}
+
+static int min_int(int a, int b) {
+  return a < b ? a : b;
+}
+
+// bigit_length includes the "hidden" digits encoded in the exponent.
+int bigit_length(bignum num) { return num.used_digits + num.exponent; }
+
+void bignum_zero(bignum* num) {
+  for (int i = 0; i < num->used_digits; ++i) {
+    num->bigits[i] = 0;
+  }
+  num->used_digits = 0;
+  num->exponent = 0;
+}
+
+
+void bignum_ensure_capacity(int size) {
+  if (size > kBigitCapacity) {
+    UNREACHABLE();
+  }
+}
+
+void bignum_clamp(bignum* num) {
+  while (num->used_digits > 0 && num->bigits[num->used_digits - 1] == 0) {
+    num->used_digits--;
+  }
+  if (num->used_digits == 0) {
+    // Zero.
+    num->exponent = 0;
+  }
+}
+
+
+int bignum_is_clamped(bignum num) {
+  return num.used_digits == 0 || num.bigits[num.used_digits - 1] != 0;
+}
+
+
+void bignum_align(bignum* num, bignum other) {
+  if (num->exponent > other.exponent) {
+    // If "X" represents a "hidden" digit (by the exponent) then we are in the
+    // following case (a == this, b == other):
+    // a:  aaaaaaXXXX   or a:   aaaaaXXX
+    // b:     bbbbbbX      b: bbbbbbbbXX
+    // We replace some of the hidden digits (X) of a with 0 digits.
+    // a:  aaaaaa000X   or a:   aaaaa0XX
+    int zero_digits = num->exponent - other.exponent;
+    bignum_ensure_capacity(num->used_digits + zero_digits);
+    for (int i = num->used_digits - 1; i >= 0; --i) {
+      num->bigits[i + zero_digits] = num->bigits[i];
+    }
+    for (int i = 0; i < zero_digits; ++i) {
+      num->bigits[i] = 0;
+    }
+    num->used_digits += zero_digits;
+    num->exponent -= zero_digits;
+    ASSERT(num->used_digits >= 0);
+    ASSERT(num->exponent >= 0);
+  }
+}
+
+
+// Guaranteed to lie in one Bigit.
+void bignum_assign_uint16(bignum* num, uint16_t value) {
+  ASSERT(kBigitSize >= uint16_bit_size(value));
+  bignum_zero(num);
+  if (value == 0) return;
+
+  bignum_ensure_capacity(1);
+  num->bigits[0] = value;
+  num->used_digits = 1;
+}
+
+
+void bignum_assign_uint64(bignum* num, uint64_t value) {
+  const int kUInt64Size = 64;
+
+  bignum_zero(num);
+  if (value == 0) return;
+
+  int needed_bigits = kUInt64Size / kBigitSize + 1;
+  bignum_ensure_capacity(needed_bigits);
+  for (int i = 0; i < needed_bigits; ++i) {
+    num->bigits[i] = value & kBigitMask;
+    value = value >> kBigitSize;
+  }
+  num->used_digits = needed_bigits;
+  bignum_clamp(num);
+}
+
+
+void bignum_assign_bignum(bignum* num, const bignum other) {
+  num->exponent = other.exponent;
+  for (int i = 0; i < other.used_digits; ++i) {
+    num->bigits[i] = other.bigits[i];
+  }
+  // Clear the excess digits (if there were any).
+  for (int i = other.used_digits; i < num->used_digits; ++i) {
+    num->bigits[i] = 0;
+  }
+  num->used_digits = other.used_digits;
+}
+
+
+static uint64_t bignum_read_uint64(const char* buffer,
+                           int from,
+                           int digits_to_read) {
+  uint64_t result = 0;
+  for (int i = from; i < from + digits_to_read; ++i) {
+    int digit = buffer[i] - '0';
+    ASSERT(0 <= digit && digit <= 9);
+    result = result * 10 + digit;
+  }
+  return result;
+}
+
+
+void bignum_assign_decimal_string(bignum* num, const char* value) {
+  // 2^64 = 18446744073709551616 > 10^19
+  const int kMaxUint64DecimalDigits = 19;
+  bignum_zero(num);
+  int length = strlen(value);
+  unsigned int pos = 0;
+  // Let's just say that each digit needs 4 bits.
+  while (length >= kMaxUint64DecimalDigits) {
+    uint64_t digits = bignum_read_uint64(value, pos, kMaxUint64DecimalDigits);
+    pos += kMaxUint64DecimalDigits;
+    length -= kMaxUint64DecimalDigits;
+    bignum_multiply_by_power_of_ten(num, kMaxUint64DecimalDigits);
+    bignum_add_uint64(num, digits);
+  }
+  uint64_t digits = bignum_read_uint64(value, pos, length);
+  bignum_multiply_by_power_of_ten(num, length);
+  bignum_add_uint64(num, digits);
+  bignum_clamp(num);
+}
+
+
+static int HexCharValue(char c) {
+  if ('0' <= c && c <= '9') return c - '0';
+  if ('a' <= c && c <= 'f') return 10 + c - 'a';
+  ASSERT('A' <= c && c <= 'F');
+  return 10 + c - 'A';
+}
+
+
+void bignum_assign_hex_string(bignum* num, const char* value) {
+  bignum_zero(num);
+  int length = strlen(value);
+
+  int needed_bigits = length * 4 / kBigitSize + 1;
+  bignum_ensure_capacity(needed_bigits);
+  int string_index = length - 1;
+  for (int i = 0; i < needed_bigits - 1; ++i) {
+    // These bigits are guaranteed to be "full".
+    Chunk current_bigit = 0;
+    for (int j = 0; j < kBigitSize / 4; j++) {
+      current_bigit += HexCharValue(value[string_index--]) << (j * 4);
+    }
+    num->bigits[i] = current_bigit;
+  }
+  num->used_digits = needed_bigits - 1;
+
+  Chunk most_significant_bigit = 0;  // Could be = 0;
+  for (int j = 0; j <= string_index; ++j) {
+    most_significant_bigit <<= 4;
+    most_significant_bigit += HexCharValue(value[j]);
+  }
+  if (most_significant_bigit != 0) {
+    num->bigits[num->used_digits] = most_significant_bigit;
+    num->used_digits++;
+  }
+  bignum_clamp(num);
+}
+
+
+void bignum_add_uint64(bignum* num, uint64_t operand) {
+  if (operand == 0) return;
+  bignum other = new_bignum();
+  bignum_assign_uint64(&other, operand);
+  bignum_add_bignum(num, other);
+}
+
+
+void bignum_add_bignum(bignum* num, const bignum other) {
+  ASSERT(bignum_is_clamped(*num));
+  ASSERT(bignum_is_clamped(other));
+
+  // If this has a greater exponent than other append zero-bigits to this.
+  // After this call num.exponent <= other.exponent.
+  bignum_align(num, other);
+
+  // There are two possibilities:
+  //   aaaaaaaaaaa 0000  (where the 0s represent a's exponent)
+  //     bbbbb 00000000
+  //   ----------------
+  //   ccccccccccc 0000
+  // or
+  //    aaaaaaaaaa 0000
+  //  bbbbbbbbb 0000000
+  //  -----------------
+  //  cccccccccccc 0000
+  // In both cases we might need a carry bigit.
+
+  bignum_ensure_capacity(
+    1 + max_int(bigit_length(*num), bigit_length(other)) - num->exponent
+  );
+  Chunk carry = 0;
+  int bigit_pos = other.exponent - num->exponent;
+  ASSERT(bigit_pos >= 0);
+  for (int i = 0; i < other.used_digits; ++i) {
+    Chunk sum = num->bigits[bigit_pos] + other.bigits[i] + carry;
+    num->bigits[bigit_pos] = sum & kBigitMask;
+    carry = sum >> kBigitSize;
+    bigit_pos++;
+  }
+
+  while (carry != 0) {
+    Chunk sum = num->bigits[bigit_pos] + carry;
+    num->bigits[bigit_pos] = sum & kBigitMask;
+    carry = sum >> kBigitSize;
+    bigit_pos++;
+  }
+  num->used_digits = max_int(bigit_pos, num->used_digits);
+  ASSERT(bignum_is_clamped(*num));
+}
+
+
+void bignum_subtract_bignum(bignum* num, const bignum other) {
+  ASSERT(bignum_is_clamped(*num));
+  ASSERT(bignum_is_clamped(other));
+  // We require this to be bigger than other.
+  ASSERT(bignum_less_equal(other, *num));
+
+  bignum_align(num, other);
+
+  int offset = other.exponent - num->exponent;
+  Chunk borrow = 0;
+  int i;
+  for (i = 0; i < other.used_digits; ++i) {
+    ASSERT((borrow == 0) || (borrow == 1));
+    Chunk difference = num->bigits[i + offset] - other.bigits[i] - borrow;
+    num->bigits[i + offset] = difference & kBigitMask;
+    borrow = difference >> (kBigNumChunkSize - 1);
+  }
+  while (borrow != 0) {
+    Chunk difference = num->bigits[i + offset] - borrow;
+    num->bigits[i + offset] = difference & kBigitMask;
+    borrow = difference >> (kBigNumChunkSize - 1);
+    ++i;
+  }
+  bignum_clamp(num);
+}
+
+
+void bignum_subtract_times(bignum* num, bignum other, int factor) {
+  ASSERT(num->exponent <= other.exponent);
+  if (factor < 3) {
+    for (int i = 0; i < factor; ++i) {
+      bignum_subtract_bignum(num, other);
+    }
+    return;
+  }
+  Chunk borrow = 0;
+  int exponent_diff = other.exponent - num->exponent;
+  for (int i = 0; i < other.used_digits; ++i) {
+    DoubleChunk product = (DoubleChunk)factor * other.bigits[i];
+    DoubleChunk remove = borrow + product;
+    Chunk difference = num->bigits[i + exponent_diff] - (remove & kBigitMask);
+    num->bigits[i + exponent_diff] = difference & kBigitMask;
+    borrow = (Chunk)((difference >> (kBigNumChunkSize - 1)) +
+                                (remove >> kBigitSize));
+  }
+  for (int i = other.used_digits + exponent_diff; i < num->used_digits; ++i) {
+    if (borrow == 0) return;
+    Chunk difference = num->bigits[i] - borrow;
+    num->bigits[i] = difference & kBigitMask;
+    borrow = difference >> (kBigNumChunkSize - 1);
+  }
+  bignum_clamp(num);
+}
+
+
+void bignum_bigits_shift_left(bignum* num, int shift_amount) {
+  ASSERT(shift_amount < kBigitSize);
+  ASSERT(shift_amount >= 0);
+  Chunk carry = 0;
+  for (int i = 0; i < num->used_digits; ++i) {
+    Chunk new_carry = num->bigits[i] >> (kBigitSize - shift_amount);
+    num->bigits[i] = ((num->bigits[i] << shift_amount) + carry) & kBigitMask;
+    carry = new_carry;
+  }
+  if (carry != 0) {
+    num->bigits[num->used_digits] = carry;
+    num->used_digits++;
+  }
+}
+
+
+void bignum_shift_left(bignum* num, int shift_amount) {
+  if (num->used_digits == 0) return;
+  num->exponent += shift_amount / kBigitSize;
+  int local_shift = shift_amount % kBigitSize;
+  bignum_ensure_capacity(num->used_digits + 1);
+  bignum_bigits_shift_left(num, local_shift);
+}
+
+
+void bignum_multiply_by_uint32(bignum* num, uint32_t factor) {
+  if (factor == 1) return;
+  if (factor == 0) {
+    bignum_zero(num);
+    return;
+  }
+  if (num->used_digits == 0) return;
+
+  // The product of a bigit with the factor is of size kBigitSize + 32.
+  // Assert that this number + 1 (for the carry) fits into double chunk.
+  ASSERT(kBigNumDoubleChunkSize >= kBigitSize + 32 + 1);
+  DoubleChunk carry = 0;
+  for (int i = 0; i < num->used_digits; ++i) {
+    DoubleChunk product = (DoubleChunk)factor * num->bigits[i] + carry;
+    num->bigits[i] = (Chunk)(product & kBigitMask);
+    carry = (product >> kBigitSize);
+  }
+  while (carry != 0) {
+    bignum_ensure_capacity(num->used_digits + 1);
+    num->bigits[num->used_digits] = carry & kBigitMask;
+    num->used_digits++;
+    carry >>= kBigitSize;
+  }
+}
+
+
+void bignum_multiply_by_uint64(bignum* num, uint64_t factor) {
+  if (factor == 1) return;
+  if (factor == 0) {
+    bignum_zero(num);
+    return;
+  }
+  ASSERT(kBigitSize < 32);
+  uint64_t carry = 0;
+  uint64_t low = factor & 0xFFFFFFFF;
+  uint64_t high = factor >> 32;
+  for (int i = 0; i < num->used_digits; ++i) {
+    uint64_t product_low = low * num->bigits[i];
+    uint64_t product_high = high * num->bigits[i];
+    uint64_t tmp = (carry & kBigitMask) + product_low;
+    num->bigits[i] = tmp & kBigitMask;
+    carry = (carry >> kBigitSize) + (tmp >> kBigitSize) +
+        (product_high << (32 - kBigitSize));
+  }
+  while (carry != 0) {
+    bignum_ensure_capacity(num->used_digits + 1);
+    num->bigits[num->used_digits] = carry & kBigitMask;
+    num->used_digits++;
+    carry >>= kBigitSize;
+  }
+}
+
+
+void bignum_multiply_by_power_of_ten(bignum* num, int exponent) {
+  const uint64_t kFive27 = UINT64_2PART_C(0x6765c793, fa10079d);
+  const uint16_t kFive1 = 5;
+  const uint16_t kFive2 = kFive1 * 5;
+  const uint16_t kFive3 = kFive2 * 5;
+  const uint16_t kFive4 = kFive3 * 5;
+  const uint16_t kFive5 = kFive4 * 5;
+  const uint16_t kFive6 = kFive5 * 5;
+  const uint32_t kFive7 = kFive6 * 5;
+  const uint32_t kFive8 = kFive7 * 5;
+  const uint32_t kFive9 = kFive8 * 5;
+  const uint32_t kFive10 = kFive9 * 5;
+  const uint32_t kFive11 = kFive10 * 5;
+  const uint32_t kFive12 = kFive11 * 5;
+  const uint32_t kFive13 = kFive12 * 5;
+  const uint32_t kFive1_to_12[] =
+      { kFive1, kFive2, kFive3, kFive4, kFive5, kFive6,
+        kFive7, kFive8, kFive9, kFive10, kFive11, kFive12 };
+
+  ASSERT(exponent >= 0);
+  if (exponent == 0) return;
+  if (num->used_digits == 0) return;
+
+  // We shift by exponent at the end just before returning.
+  int remaining_exponent = exponent;
+  while (remaining_exponent >= 27) {
+    bignum_multiply_by_uint64(num, kFive27);
+    remaining_exponent -= 27;
+  }
+  while (remaining_exponent >= 13) {
+    bignum_multiply_by_uint32(num, kFive13);
+    remaining_exponent -= 13;
+  }
+  if (remaining_exponent > 0) {
+    bignum_multiply_by_uint32(num, kFive1_to_12[remaining_exponent - 1]);
+  }
+  bignum_shift_left(num, exponent);
+}
+
+
+void bignum_times_10(bignum* num) {
+  return bignum_multiply_by_uint32(num, 10);
+}
+
+
+void bignum_square(bignum* num) {
+  ASSERT(bignum_is_clamped(*num));
+  int product_length = 2 * num->used_digits;
+  bignum_ensure_capacity(product_length);
+
+  // Comba multiplication: compute each column separately.
+  // Example: r = a2a1a0 * b2b1b0.
+  //    r =  1    * a0b0 +
+  //        10    * (a1b0 + a0b1) +
+  //        100   * (a2b0 + a1b1 + a0b2) +
+  //        1000  * (a2b1 + a1b2) +
+  //        10000 * a2b2
+  //
+  // In the worst case we have to accumulate nb-digits products of digit*digit.
+  //
+  // Assert that the additional number of bits in a DoubleChunk are enough to
+  // sum up used_digits of Bigit*Bigit.
+  if ((1 << (2 * (kBigNumChunkSize - kBigitSize))) <= num->used_digits) {
+    UNIMPLEMENTED();
+  }
+  DoubleChunk accumulator = 0;
+  // First shift the digits so we don't overwrite them.
+  int copy_offset = num->used_digits;
+  for (int i = 0; i < num->used_digits; ++i) {
+    num->bigits[copy_offset + i] = num->bigits[i];
+  }
+  // We have two loops to avoid some 'if's in the loop.
+  for (int i = 0; i < num->used_digits; ++i) {
+    // Process temporary digit i with power i.
+    // The sum of the two indices must be equal to i.
+    int bigit_index1 = i;
+    int bigit_index2 = 0;
+    // Sum all of the sub-products.
+    while (bigit_index1 >= 0) {
+      Chunk chunk1 = num->bigits[copy_offset + bigit_index1];
+      Chunk chunk2 = num->bigits[copy_offset + bigit_index2];
+      accumulator += (DoubleChunk)chunk1 * chunk2;
+      bigit_index1--;
+      bigit_index2++;
+    }
+    num->bigits[i] = (Chunk)accumulator & kBigitMask;
+    accumulator >>= kBigitSize;
+  }
+  for (int i = num->used_digits; i < product_length; ++i) {
+    int bigit_index1 = num->used_digits - 1;
+    int bigit_index2 = i - bigit_index1;
+    // Invariant: sum of both indices is again equal to i.
+    // Inner loop runs 0 times on last iteration, emptying accumulator.
+    while (bigit_index2 < num->used_digits) {
+      Chunk chunk1 = num->bigits[copy_offset + bigit_index1];
+      Chunk chunk2 = num->bigits[copy_offset + bigit_index2];
+      accumulator += (DoubleChunk)chunk1 * chunk2;
+      bigit_index1--;
+      bigit_index2++;
+    }
+    // The overwritten num->bigits[i] will never be read in further loop
+    // iterations, because bigit_index1 and bigit_index2 are always greater
+    // than i - num->used_digits.
+    num->bigits[i] = (Chunk)accumulator & kBigitMask;
+    accumulator >>= kBigitSize;
+  }
+  // Since the result was guaranteed to lie inside the number the
+  // accumulator must be 0 now.
+  ASSERT(accumulator == 0);
+
+  // Don't forget to update the used_digits and the exponent.
+  num->used_digits = product_length;
+  num->exponent *= 2;
+  bignum_clamp(num);
+}
+
+
+void bignum_assign_power_uint16(
+  bignum* num,
+  uint16_t base,
+  int power_exponent
+) {
+  ASSERT(base != 0);
+  ASSERT(power_exponent >= 0);
+  if (power_exponent == 0) {
+    bignum_assign_uint16(num, 1);
+    return;
+  }
+  bignum_zero(num);
+  int shifts = 0;
+  // We expect base to be in range 2-32, and most often to be 10.
+  // It does not make much sense to implement different algorithms for counting
+  // the bits.
+  while ((base & 1) == 0) {
+    base >>= 1;
+    shifts++;
+  }
+  int bit_size = 0;
+  int tmp_base = base;
+  while (tmp_base != 0) {
+    tmp_base >>= 1;
+    bit_size++;
+  }
+  int final_size = bit_size * power_exponent;
+  // 1 extra bigit for the shifting, and one for rounded final_size.
+  bignum_ensure_capacity(final_size / kBigitSize + 2);
+
+  // Left to Right exponentiation.
+  int mask = 1;
+  while (power_exponent >= mask) mask <<= 1;
+
+  // The mask is now pointing to the bit above the most significant 1-bit of
+  // power_exponent.
+  // Get rid of first 1-bit;
+  mask >>= 2;
+  uint64_t this_value = base;
+
+  bool delayed_multipliciation = false;
+  const uint64_t max_32bits = 0xFFFFFFFF;
+  while (mask != 0 && this_value <= max_32bits) {
+    this_value = this_value * this_value;
+    // Verify that there is enough space in this_value to perform the
+    // multiplication.  The first bit_size bits must be 0.
+    if ((power_exponent & mask) != 0) {
+      uint64_t base_bits_mask =
+          ~(((uint64_t)1 << (64 - bit_size)) - 1);
+      bool high_bits_zero = (this_value & base_bits_mask) == 0;
+      if (high_bits_zero) {
+        this_value *= base;
+      } else {
+        delayed_multipliciation = true;
+      }
+    }
+    mask >>= 1;
+  }
+  bignum_assign_uint64(num, this_value);
+  if (delayed_multipliciation) {
+    bignum_multiply_by_uint32(num, base);
+  }
+
+  // Now do the same thing as a bignum.
+  while (mask != 0) {
+    bignum_square(num);
+    if ((power_exponent & mask) != 0) {
+      bignum_multiply_by_uint32(num, base);
+    }
+    mask >>= 1;
+  }
+
+  // And finally add the saved shifts.
+  bignum_shift_left(num, shifts * power_exponent);
+}
+
+
+// Precondition: this/other < 16bit.
+uint16_t bignum_divide_modulo_int_bignum(bignum* num, const bignum other) {
+  ASSERT(bignum_is_clamped(*num));
+  ASSERT(bignum_is_clamped(other));
+  ASSERT(other.used_digits > 0);
+
+  // Easy case: if we have less digits than the divisor than the result is 0.
+  // Note: this handles the case where this == 0, too.
+  if (bigit_length(*num) < bigit_length(other)) {
+    return 0;
+  }
+
+  bignum_align(num, other);
+
+  uint16_t result = 0;
+
+  // Start by removing multiples of 'other' until both numbers have the same
+  // number of digits.
+  while (bigit_length(*num) > bigit_length(other)) {
+    // This naive approach is extremely inefficient if `this` divided by other
+    // is big. This function is implemented for doubleToString where
+    // the result should be small (less than 10).
+    ASSERT(other.bigits[other.used_digits - 1] >= ((1 << kBigitSize) / 16));
+    ASSERT(num->bigits[num->used_digits - 1] < 0x10000);
+    // Remove the multiples of the first digit.
+    // Example this = 23 and other equals 9. -> Remove 2 multiples.
+    result += (uint16_t)(num->bigits[num->used_digits - 1]);
+    bignum_subtract_times(num, other, num->bigits[num->used_digits - 1]);
+  }
+
+  ASSERT(bigit_length(*num) == bigit_length(other));
+
+  // Both bignums are at the same length now.
+  // Since other has more than 0 digits we know that the access to
+  // num.bigits[num.used_digits - 1] is safe.
+  Chunk this_bigit = num->bigits[num->used_digits - 1];
+  Chunk other_bigit = other.bigits[other.used_digits - 1];
+
+  if (other.used_digits == 1) {
+    // Shortcut for easy (and common) case.
+    int quotient = this_bigit / other_bigit;
+    num->bigits[num->used_digits - 1] = this_bigit - other_bigit * quotient;
+    ASSERT(quotient < 0x10000);
+    result += (uint16_t)quotient;
+    bignum_clamp(num);
+    return result;
+  }
+
+  int division_estimate = this_bigit / (other_bigit + 1);
+  ASSERT(division_estimate < 0x10000);
+  result += (uint16_t)division_estimate;
+  bignum_subtract_times(num, other, division_estimate);
+
+  if (other_bigit * (division_estimate + 1) > this_bigit) {
+    // No need to even try to subtract. Even if other's remaining digits were 0
+    // another subtraction would be too much.
+    return result;
+  }
+
+  while (bignum_less_equal(other, *num)) {
+    bignum_subtract_bignum(num, other);
+    result++;
+  }
+  return result;
+}
+
+
+static int chunk_size_in_hex_chars(Chunk number) {
+  ASSERT(number > 0);
+  int result = 0;
+  while (number != 0) {
+    number >>= 4;
+    result++;
+  }
+  return result;
+}
+
+
+static char HexCharOfValue(int value) {
+  ASSERT(0 <= value && value <= 16);
+  if (value < 10) return (char)(value + '0');
+  return (char)(value - 10 + 'A');
+}
+
+
+bool bignum_to_hex_string(bignum num, char* buffer, int buffer_size) {
+  ASSERT(bignum_is_clamped(num));
+  // Each bigit must be printable as separate hex-character.
+  ASSERT(kBigitSize % 4 == 0);
+  const int kHexCharsPerBigit = kBigitSize / 4;
+
+  if (num.used_digits == 0) {
+    if (buffer_size < 2) return false;
+    buffer[0] = '0';
+    buffer[1] = '\0';
+    return true;
+  }
+  // We add 1 for the terminating '\0' character.
+  int needed_chars = (bigit_length(num) - 1) * kHexCharsPerBigit +
+      chunk_size_in_hex_chars(num.bigits[num.used_digits - 1]) + 1;
+  if (needed_chars > buffer_size) return false;
+  int string_index = needed_chars - 1;
+  buffer[string_index--] = '\0';
+  for (int i = 0; i < num.exponent; ++i) {
+    for (int j = 0; j < kHexCharsPerBigit; ++j) {
+      buffer[string_index--] = '0';
+    }
+  }
+  for (int i = 0; i < num.used_digits - 1; ++i) {
+    Chunk current_bigit = num.bigits[i];
+    for (int j = 0; j < kHexCharsPerBigit; ++j) {
+      buffer[string_index--] = HexCharOfValue(current_bigit & 0xF);
+      current_bigit >>= 4;
+    }
+  }
+  // And finally the last bigit.
+  Chunk most_significant_bigit = num.bigits[num.used_digits - 1];
+  while (most_significant_bigit != 0) {
+    buffer[string_index--] = HexCharOfValue(most_significant_bigit & 0xF);
+    most_significant_bigit >>= 4;
+  }
+  return true;
+}
+
+
+Chunk bignum_bigit_at(bignum num, int index) {
+  if (index >= bigit_length(num)) return 0;
+  if (index < num.exponent) return 0;
+  return num.bigits[index - num.exponent];
+}
+
+
+int bignum_compare(bignum a, bignum b) {
+  ASSERT(bignum_is_clamped(a));
+  ASSERT(bignum_is_clamped(b));
+  int bigit_length_a = bigit_length(a);
+  int bigit_length_b = bigit_length(b);
+  if (bigit_length_a < bigit_length_b) return -1;
+  if (bigit_length_a > bigit_length_b) return +1;
+  for (int i = bigit_length_a - 1; i >= min_int(a.exponent, b.exponent); --i) {
+    Chunk bigit_a = bignum_bigit_at(a, i);
+    Chunk bigit_b = bignum_bigit_at(b, i);
+    if (bigit_a < bigit_b) return -1;
+    if (bigit_a > bigit_b) return +1;
+    // Otherwise they are equal up to this digit. Try the next digit.
+  }
+  return 0;
+}
+
+bool bignum_equal(bignum a, bignum b) {
+  return bignum_compare(a, b) == 0;
+}
+bool bignum_less_equal(bignum a, bignum b) {
+  return bignum_compare(a, b) <= 0;
+}
+bool bignum_less(bignum a, bignum b) {
+  return bignum_compare(a, b) < 0;
+}
+
+
+int bignum_plus_compare(bignum a, bignum b, bignum c) {
+  ASSERT(bignum_is_clamped(a));
+  ASSERT(bignum_is_clamped(b));
+  ASSERT(bignum_is_clamped(c));
+  if (bigit_length(a) < bigit_length(b)) {
+    return bignum_plus_compare(b, a, c);
+  }
+  if (bigit_length(a) + 1 < bigit_length(c)) return -1;
+  if (bigit_length(a) > bigit_length(c)) return +1;
+  // The exponent encodes 0-bigits. So if there are more 0-digits in 'a' than
+  // 'b' has digits, then the bigit-length of 'a'+'b' must be equal to the one
+  // of 'a'.
+  if (a.exponent >= bigit_length(b) && bigit_length(a) < bigit_length(c)) {
+    return -1;
+  }
+
+  Chunk borrow = 0;
+  // Starting at min_exponent all digits are == 0. So no need to compare them.
+  int min_exponent = min_int(min_int(a.exponent, b.exponent), c.exponent);
+  for (int i = bigit_length(c) - 1; i >= min_exponent; --i) {
+    Chunk chunk_a = bignum_bigit_at(a, i);
+    Chunk chunk_b = bignum_bigit_at(b, i);
+    Chunk chunk_c = bignum_bigit_at(c, i);
+    Chunk sum = chunk_a + chunk_b;
+    if (sum > chunk_c + borrow) {
+      return +1;
+    } else {
+      borrow = chunk_c + borrow - sum;
+      if (borrow > 1) return -1;
+      borrow <<= kBigitSize;
+    }
+  }
+  if (borrow == 0) return 0;
+  return -1;
+}
+
+bool bignum_plus_equal(bignum a, bignum b, bignum c) {
+  return bignum_plus_compare(a, b, c) == 0;
+}
+// Returns a + b <= c
+bool bignum_plus_less_equal(bignum a, bignum b, bignum c) {
+  return bignum_plus_compare(a, b, c) <= 0;
+}
+// Returns a + b < c
+bool bignum_plus_less(bignum a, bignum b, bignum c) {
+  return bignum_plus_compare(a, b, c) < 0;
+}

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) 2010, the V8 project authors.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef OCAML_DTOA_BIGNUM_H_
+#define OCAML_DTOA_BIGNUM_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "utils.h"
+
+typedef uint32_t Chunk;
+typedef uint64_t DoubleChunk;
+
+extern const int kBigNumMaxSignificantBits;
+extern const int kBigitSize;
+extern const Chunk kBigitMask;
+extern const int kBigitCapacity;
+
+typedef struct {
+  Chunk bigits[128]; // 128 = kBigitCapacity
+  int used_digits;
+  // The Bignum's value equals value(bigits_) * 2^(exponent_ * kBigitSize).
+  int exponent;
+} bignum;
+
+bignum new_bignum();
+
+void bignum_assign_uint16(bignum* num, uint16_t value);
+void bignum_assign_uint64(bignum* num, uint64_t value);
+void bignum_assign_bignum(bignum* num, bignum other);
+
+void bignum_assign_decimal_string(bignum* num, const char* value);
+void bignum_assign_hex_string(bignum* num, const char* value);
+
+void bignum_assign_power_uint16(bignum* num, uint16_t base, int power_exponent);
+
+void bignum_add_uint64(bignum* num, uint64_t operand);
+void bignum_add_bignum(bignum* num, bignum other);
+// Precondition: this >= other.
+void bignum_subtract_bignum(bignum* num, bignum other);
+
+void bignum_square(bignum* num);
+void bignum_shift_left(bignum* num, int shift_amount);
+void bignum_multiply_by_uint32(bignum* num, uint32_t factor);
+void bignum_multiply_by_uint64(bignum* num, uint64_t factor);
+void bignum_multiply_by_power_of_ten(bignum* num, int exponent);
+void bignum_times_10(bignum* num);
+// Pseudocode:
+//  int result = this / other;
+//  this = this % other;
+// In the worst case this function is in O(this/other).
+uint16_t bignum_divide_modulo_int_bignum(bignum* num, bignum other);
+
+bool bignum_to_hex_string(bignum num, char* buffer, int buffer_size);
+
+// Returns
+//  -1 if a < b,
+//   0 if a == b, and
+//  +1 if a > b.
+int bignum_compare(bignum a, bignum b);
+bool bignum_equal(bignum a, bignum b);
+bool bignum_less_equal(bignum a, bignum b);
+bool bignum_less(bignum a, bignum b);
+// Returns Compare(a + b, c);
+int bignum_plus_compare(bignum a, bignum b, bignum c);
+// Returns a + b == c
+bool bignum_plus_equal(bignum a, bignum b, bignum c);
+// Returns a + b <= c
+bool bignum_plus_less_equal(bignum a, bignum b, bignum c);
+// Returns a + b < c
+bool bignum_plus_less(bignum a, bignum b, bignum c);
+
+#endif  // OCAML_DTOA_BIGNUM_H_

--- a/src/bignum_dtoa.c
+++ b/src/bignum_dtoa.c
@@ -1,0 +1,629 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) 2010, the V8 project authors.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <math.h>
+
+#include "bignum_dtoa.h"
+
+#include "bignum.h"
+#include "ieee.h"
+
+static int NormalizedExponent(uint64_t significand, int exponent) {
+  ASSERT(significand != 0);
+  while ((significand & kDoubleHiddenBit) == 0) {
+    significand = significand << 1;
+    exponent = exponent - 1;
+  }
+  return exponent;
+}
+
+
+// Forward declarations:
+// Returns an estimation of k such that 10^(k-1) <= v < 10^k.
+static int EstimatePower(int exponent);
+// Computes v / 10^estimated_power exactly, as a ratio of two bignums, numerator
+// and denominator.
+static void InitialScaledStartValues(uint64_t significand,
+                                     int exponent,
+                                     bool lower_boundary_is_closer,
+                                     int estimated_power,
+                                     bool need_boundary_deltas,
+                                     bignum* numerator,
+                                     bignum* denominator,
+                                     bignum* delta_minus,
+                                     bignum* delta_plus);
+// Multiplies numerator/denominator so that its values lies in the range 1-10.
+// Returns decimal_point s.t.
+//  v = numerator'/denominator' * 10^(decimal_point-1)
+//     where numerator' and denominator' are the values of numerator and
+//     denominator after the call to this function.
+static void FixupMultiply10(int estimated_power, bool is_even,
+                            int* decimal_point,
+                            bignum* numerator, bignum* denominator,
+                            bignum* delta_minus, bignum* delta_plus);
+// Generates digits from the left to the right and stops when the generated
+// digits yield the shortest decimal representation of v.
+static void GenerateShortestDigits(bignum* numerator, bignum* denominator,
+                                   bignum* delta_minus, bignum* delta_plus,
+                                   bool is_even,
+                                   char* buffer, int* length);
+// Generates 'requested_digits' after the decimal point.
+static void BignumToFixed(int requested_digits, int* decimal_point,
+                          bignum* numerator, bignum* denominator,
+                          char*(buffer), int* length);
+// Generates 'count' digits of numerator/denominator.
+// Once 'count' digits have been produced rounds the result depending on the
+// remainder (remainders of exactly .5 round upwards). Might update the
+// decimal_point when rounding up (for example for 0.9999).
+static void GenerateCountedDigits(int count, int* decimal_point,
+                                  bignum* numerator, bignum* denominator,
+                                  char*(buffer), int* length);
+
+
+void bignum_dtoa(
+  double v,
+  BignumDtoaMode mode,
+  int requested_digits,
+  char* buffer,
+  int* length,
+  int* decimal_point
+) {
+  ASSERT(v > 0);
+  ASSERT(!double_is_special(v));
+  uint64_t significand;
+  int exponent;
+  bool lower_boundary_is_closer;
+  if (mode == BIGNUM_DTOA_SHORTEST_SINGLE) {
+    // TODO
+    // float f = (float)v;
+    // ASSERT(f == v);
+    // significand = Single(f).Significand();
+    // exponent = Single(f).Exponent();
+    // lower_boundary_is_closer = Single(f).LowerBoundaryIsCloser();
+    UNIMPLEMENTED();
+  } else {
+    significand = double_significand(v);
+    exponent = double_exponent(v);
+    lower_boundary_is_closer = double_lower_boundary_is_closer(v);
+  }
+  bool need_boundary_deltas =
+      (mode == BIGNUM_DTOA_SHORTEST || mode == BIGNUM_DTOA_SHORTEST_SINGLE);
+
+  bool is_even = (significand & 1) == 0;
+  int normalized_exponent = NormalizedExponent(significand, exponent);
+  // estimated_power might be too low by 1.
+  int estimated_power = EstimatePower(normalized_exponent);
+
+  // Shortcut for Fixed.
+  // The requested digits correspond to the digits after the point. If the
+  // number is much too small, then there is no need in trying to get any
+  // digits.
+  if (mode == BIGNUM_DTOA_FIXED && -estimated_power - 1 > requested_digits) {
+    buffer[0] = '\0';
+    *length = 0;
+    // Set decimal-point to -requested_digits. This is what Gay does.
+    // Note that it should not have any effect anyways since the string is
+    // empty.
+    *decimal_point = -requested_digits;
+    return;
+  }
+
+  bignum numerator = new_bignum();
+  bignum denominator = new_bignum();
+  bignum delta_minus = new_bignum();
+  bignum delta_plus = new_bignum();
+  // Make sure the bignum can grow large enough. The smallest double equals
+  // 4e-324. In this case the denominator needs fewer than 324*4 binary digits.
+  // The maximum double is 1.7976931348623157e308 which needs fewer than
+  // 308*4 binary digits.
+  ASSERT(kBigNumMaxSignificantBits >= 324*4);
+
+  InitialScaledStartValues(significand, exponent, lower_boundary_is_closer,
+                           estimated_power, need_boundary_deltas,
+                           &numerator, &denominator,
+                           &delta_minus, &delta_plus);
+
+  // We now have v = (numerator / denominator) * 10^estimated_power.
+  FixupMultiply10(estimated_power, is_even, decimal_point,
+                  &numerator, &denominator,
+                  &delta_minus, &delta_plus);
+
+  // We now have v = (numerator / denominator) * 10^(decimal_point-1), and
+  //  1 <= (numerator + delta_plus) / denominator < 10
+  switch (mode) {
+    case BIGNUM_DTOA_SHORTEST:
+    case BIGNUM_DTOA_SHORTEST_SINGLE:
+      GenerateShortestDigits(&numerator, &denominator,
+                             &delta_minus, &delta_plus,
+                             is_even, buffer, length);
+      break;
+    case BIGNUM_DTOA_FIXED:
+      BignumToFixed(requested_digits, decimal_point,
+                    &numerator, &denominator,
+                    buffer, length);
+      break;
+    case BIGNUM_DTOA_PRECISION:
+      GenerateCountedDigits(requested_digits, decimal_point,
+                            &numerator, &denominator,
+                            buffer, length);
+      break;
+    default:
+      UNREACHABLE();
+  }
+  buffer[*length] = '\0';
+}
+
+
+// The procedure starts generating digits from the left to the right and stops
+// when the generated digits yield the shortest decimal representation of v. A
+// decimal representation of v is a number lying closer to v than to any other
+// double, so it converts to v when read.
+//
+// This is true if d, the decimal representation, is between m- and m+, the
+// upper and lower boundaries. d must be strictly between them if !is_even.
+//           m- := (numerator - delta_minus) / denominator
+//           m+ := (numerator + delta_plus) / denominator
+//
+// Precondition: 0 <= (numerator+delta_plus) / denominator < 10.
+//   If 1 <= (numerator+delta_plus) / denominator < 10 then no leading 0 digit
+//   will be produced. This should be the standard precondition.
+static void GenerateShortestDigits(bignum* numerator, bignum* denominator,
+                                   bignum* delta_minus, bignum* delta_plus,
+                                   bool is_even,
+                                   char* buffer, int* length) {
+  // Small optimization: if delta_minus and delta_plus are the same just reuse
+  // one of the two bignums.
+  if (bignum_equal(*delta_minus, *delta_plus)) {
+    delta_plus = delta_minus;
+  }
+  *length = 0;
+  for (;;) {
+    uint16_t digit;
+    digit = bignum_divide_modulo_int_bignum(numerator, *denominator);
+    ASSERT(digit <= 9);  // digit is a uint16_t and therefore always positive.
+    // digit = numerator / denominator (integer division).
+    // numerator = numerator % denominator.
+    buffer[(*length)++] = (char)(digit + '0');
+
+    // Can we stop already?
+    // If the remainder of the division is less than the distance to the lower
+    // boundary we can stop. In this case we simply round down (discarding the
+    // remainder).
+    // Similarly we test if we can round up (using the upper boundary).
+    bool in_delta_room_minus;
+    bool in_delta_room_plus;
+    if (is_even) {
+      in_delta_room_minus = bignum_less_equal(*numerator, *delta_minus);
+    } else {
+      in_delta_room_minus = bignum_less(*numerator, *delta_minus);
+    }
+    if (is_even) {
+      in_delta_room_plus =
+          bignum_plus_compare(*numerator, *delta_plus, *denominator) >= 0;
+    } else {
+      in_delta_room_plus =
+          bignum_plus_compare(*numerator, *delta_plus, *denominator) > 0;
+    }
+    if (!in_delta_room_minus && !in_delta_room_plus) {
+      // Prepare for next iteration.
+      bignum_times_10(numerator);
+      bignum_times_10(delta_minus);
+      // We optimized delta_plus to be equal to delta_minus (if they share the
+      // same value). So don't multiply delta_plus if they point to the same
+      // object.
+      if (delta_minus != delta_plus) {
+        bignum_times_10(delta_plus);
+      }
+    } else if (in_delta_room_minus && in_delta_room_plus) {
+      // Let's see if 2*numerator < denominator.
+      // If yes, then the next digit would be < 5 and we can round down.
+      int compare = bignum_plus_compare(*numerator, *numerator, *denominator);
+      if (compare < 0) {
+        // Remaining digits are less than .5. -> Round down (== do nothing).
+      } else if (compare > 0) {
+        // Remaining digits are more than .5 of denominator. -> Round up.
+        // Note that the last digit could not be a '9' as otherwise the whole
+        // loop would have stopped earlier.
+        // We still have an assert here in case the preconditions were not
+        // satisfied.
+        ASSERT(buffer[(*length) - 1] != '9');
+        buffer[(*length) - 1]++;
+      } else {
+        // Halfway case.
+        // TODO(floitsch): need a way to solve half-way cases.
+        //   For now let's round towards even (since this is what Gay seems to
+        //   do).
+
+        if ((buffer[(*length) - 1] - '0') % 2 == 0) {
+          // Round down => Do nothing.
+        } else {
+          ASSERT(buffer[(*length) - 1] != '9');
+          buffer[(*length) - 1]++;
+        }
+      }
+      return;
+    } else if (in_delta_room_minus) {
+      // Round down (== do nothing).
+      return;
+    } else {  // in_delta_room_plus
+      // Round up.
+      // Note again that the last digit could not be '9' since this would have
+      // stopped the loop earlier.
+      // We still have an ASSERT here, in case the preconditions were not
+      // satisfied.
+      ASSERT(buffer[(*length) -1] != '9');
+      buffer[(*length) - 1]++;
+      return;
+    }
+  }
+}
+
+
+// Let v = numerator / denominator < 10.
+// Then we generate 'count' digits of d = x.xxxxx... (without the decimal point)
+// from left to right. Once 'count' digits have been produced we decide wether
+// to round up or down. Remainders of exactly .5 round upwards. Numbers such
+// as 9.999999 propagate a carry all the way, and change the
+// exponent (decimal_point), when rounding upwards.
+static void GenerateCountedDigits(int count, int* decimal_point,
+                                  bignum* numerator, bignum* denominator,
+                                  char* buffer, int* length) {
+  ASSERT(count >= 0);
+  for (int i = 0; i < count - 1; ++i) {
+    uint16_t digit;
+    digit = bignum_divide_modulo_int_bignum(numerator, *denominator);
+    ASSERT(digit <= 9);  // digit is a uint16_t and therefore always positive.
+    // digit = numerator / denominator (integer division).
+    // numerator = numerator % denominator.
+    buffer[i] = (char)(digit + '0');
+    // Prepare for next iteration.
+    bignum_times_10(numerator);
+  }
+  // Generate the last digit.
+  uint16_t digit;
+  digit = bignum_divide_modulo_int_bignum(numerator, *denominator);
+  if (bignum_plus_compare(*numerator, *numerator, *denominator) >= 0) {
+    digit++;
+  }
+  ASSERT(digit <= 10);
+  buffer[count - 1] = (char)(digit + '0');
+  // Correct bad digits (in case we had a sequence of '9's). Propagate the
+  // carry until we hat a non-'9' or til we reach the first digit.
+  for (int i = count - 1; i > 0; --i) {
+    if (buffer[i] != '0' + 10) break;
+    buffer[i] = '0';
+    buffer[i - 1]++;
+  }
+  if (buffer[0] == '0' + 10) {
+    // Propagate a carry past the top place.
+    buffer[0] = '1';
+    (*decimal_point)++;
+  }
+  *length = count;
+}
+
+
+// Generates 'requested_digits' after the decimal point. It might omit
+// trailing '0's. If the input number is too small then no digits at all are
+// generated (ex.: 2 fixed digits for 0.00001).
+//
+// Input verifies:  1 <= (numerator + delta) / denominator < 10.
+static void BignumToFixed(int requested_digits, int* decimal_point,
+                          bignum* numerator, bignum* denominator,
+                          char* buffer, int* length) {
+  // Note that we have to look at more than just the requested_digits, since
+  // a number could be rounded up. Example: v=0.5 with requested_digits=0.
+  // Even though the power of v equals 0 we can't just stop here.
+  if (-(*decimal_point) > requested_digits) {
+    // The number is definitively too small.
+    // Ex: 0.001 with requested_digits == 1.
+    // Set decimal-point to -requested_digits. This is what Gay does.
+    // Note that it should not have any effect anyways since the string is
+    // empty.
+    *decimal_point = -requested_digits;
+    *length = 0;
+    return;
+  } else if (-(*decimal_point) == requested_digits) {
+    // We only need to verify if the number rounds down or up.
+    // Ex: 0.04 and 0.06 with requested_digits == 1.
+    ASSERT(*decimal_point == -requested_digits);
+    // Initially the fraction lies in range (1, 10]. Multiply the denominator
+    // by 10 so that we can compare more easily.
+    bignum_times_10(denominator);
+    if (bignum_plus_compare(*numerator, *numerator, *denominator) >= 0) {
+      // If the fraction is >= 0.5 then we have to include the rounded
+      // digit.
+      buffer[0] = '1';
+      *length = 1;
+      (*decimal_point)++;
+    } else {
+      // Note that we caught most of similar cases earlier.
+      *length = 0;
+    }
+    return;
+  } else {
+    // The requested digits correspond to the digits after the point.
+    // The variable 'needed_digits' includes the digits before the point.
+    int needed_digits = (*decimal_point) + requested_digits;
+    GenerateCountedDigits(needed_digits, decimal_point,
+                          numerator, denominator,
+                          buffer, length);
+  }
+}
+
+
+// Returns an estimation of k such that 10^(k-1) <= v < 10^k where
+// v = f * 2^exponent and 2^52 <= f < 2^53.
+// v is hence a normalized double with the given exponent. The output is an
+// approximation for the exponent of the decimal approimation .digits * 10^k.
+//
+// The result might undershoot by 1 in which case 10^k <= v < 10^k+1.
+// Note: this property holds for v's upper boundary m+ too.
+//    10^k <= m+ < 10^k+1.
+//   (see explanation below).
+//
+// Examples:
+//  EstimatePower(0)   => 16
+//  EstimatePower(-52) => 0
+//
+// Note: e >= 0 => EstimatedPower(e) > 0. No similar claim can be made for e<0.
+static int EstimatePower(int exponent) {
+  // This function estimates log10 of v where v = f*2^e (with e == exponent).
+  // Note that 10^floor(log10(v)) <= v, but v <= 10^ceil(log10(v)).
+  // Note that f is bounded by its container size. Let p = 53 (the double's
+  // significand size). Then 2^(p-1) <= f < 2^p.
+  //
+  // Given that log10(v) == log2(v)/log2(10) and e+(len(f)-1) is quite close
+  // to log2(v) the function is simplified to (e+(len(f)-1)/log2(10)).
+  // The computed number undershoots by less than 0.631 (when we compute log3
+  // and not log10).
+  //
+  // Optimization: since we only need an approximated result this computation
+  // can be performed on 64 bit integers. On x86/x64 architecture the speedup is
+  // not really measurable, though.
+  //
+  // Since we want to avoid overshooting we decrement by 1e10 so that
+  // floating-point imprecisions don't affect us.
+  //
+  // Explanation for v's boundary m+: the computation takes advantage of
+  // the fact that 2^(p-1) <= f < 2^p. Boundaries still satisfy this requirement
+  // (even for denormals where the delta can be much more important).
+
+  const double k1Log10 = 0.30102999566398114;  // 1/lg(10)
+
+  // For doubles len(f) == 53 (don't forget the hidden bit).
+  const int kSignificandSize = kDoubleSignificandSize;
+  double estimate = ceil((exponent + kSignificandSize - 1) * k1Log10 - 1e-10);
+  return (int)estimate;
+}
+
+
+// See comments for InitialScaledStartValues.
+static void InitialScaledStartValuesPositiveExponent(
+    uint64_t significand, int exponent,
+    int estimated_power, bool need_boundary_deltas,
+    bignum* numerator, bignum* denominator,
+    bignum* delta_minus, bignum* delta_plus) {
+  // A positive exponent implies a positive power.
+  ASSERT(estimated_power >= 0);
+  // Since the estimated_power is positive we simply multiply the denominator
+  // by 10^estimated_power.
+
+  // numerator = v.
+  bignum_assign_uint64(numerator, significand);
+  bignum_shift_left(numerator, exponent);
+  // denominator = 10^estimated_power.
+  bignum_assign_power_uint16(denominator, 10, estimated_power);
+
+  if (need_boundary_deltas) {
+    // Introduce a common denominator so that the deltas to the boundaries are
+    // integers.
+    bignum_shift_left(denominator, 1);
+    bignum_shift_left(numerator, 1);
+    // Let v = f * 2^e, then m+ - v = 1/2 * 2^e; With the common
+    // denominator (of 2) delta_plus equals 2^e.
+    bignum_assign_uint16(delta_plus, 1);
+    bignum_shift_left(delta_plus, exponent);
+    // Same for delta_minus. The adjustments if f == 2^p-1 are done later.
+    bignum_assign_uint16(delta_minus, 1);
+    bignum_shift_left(delta_minus, exponent);
+  }
+}
+
+
+// See comments for InitialScaledStartValues
+static void InitialScaledStartValuesNegativeExponentPositivePower(
+    uint64_t significand, int exponent,
+    int estimated_power, bool need_boundary_deltas,
+    bignum* numerator, bignum* denominator,
+    bignum* delta_minus, bignum* delta_plus) {
+  // v = f * 2^e with e < 0, and with estimated_power >= 0.
+  // This means that e is close to 0 (have a look at how estimated_power is
+  // computed).
+
+  // numerator = significand
+  //  since v = significand * 2^exponent this is equivalent to
+  //  numerator = v * / 2^-exponent
+  bignum_assign_uint64(numerator, significand);
+  // denominator = 10^estimated_power * 2^-exponent (with exponent < 0)
+  bignum_assign_power_uint16(denominator, 10, estimated_power);
+  bignum_shift_left(denominator, -exponent);
+
+  if (need_boundary_deltas) {
+    // Introduce a common denominator so that the deltas to the boundaries are
+    // integers.
+    bignum_shift_left(denominator, 1);
+    bignum_shift_left(numerator, 1);
+    // Let v = f * 2^e, then m+ - v = 1/2 * 2^e; With the common
+    // denominator (of 2) delta_plus equals 2^e.
+    // Given that the denominator already includes v's exponent the distance
+    // to the boundaries is simply 1.
+    bignum_assign_uint16(delta_plus, 1);
+    // Same for delta_minus. The adjustments if f == 2^p-1 are done later.
+    bignum_assign_uint16(delta_minus, 1);
+  }
+}
+
+
+// See comments for InitialScaledStartValues
+static void InitialScaledStartValuesNegativeExponentNegativePower(
+    uint64_t significand, int exponent,
+    int estimated_power, bool need_boundary_deltas,
+    bignum* numerator, bignum* denominator,
+    bignum* delta_minus, bignum* delta_plus) {
+  // Instead of multiplying the denominator with 10^estimated_power we
+  // multiply all values (numerator and deltas) by 10^-estimated_power.
+
+  // Use numerator as temporary container for power_ten.
+  bignum* power_ten = numerator;
+  bignum_assign_power_uint16(power_ten, 10, -estimated_power);
+
+  if (need_boundary_deltas) {
+    // Since power_ten == numerator we must make a copy of 10^estimated_power
+    // before we complete the computation of the numerator.
+    // delta_plus = delta_minus = 10^estimated_power
+    bignum_assign_bignum(delta_plus, *power_ten);
+    bignum_assign_bignum(delta_minus, *power_ten);
+  }
+
+  // numerator = significand * 2 * 10^-estimated_power
+  //  since v = significand * 2^exponent this is equivalent to
+  // numerator = v * 10^-estimated_power * 2 * 2^-exponent.
+  // Remember: numerator has been abused as power_ten. So no need to assign it
+  //  to itself.
+  ASSERT(numerator == power_ten);
+  bignum_multiply_by_uint64(numerator, significand);
+
+  // denominator = 2 * 2^-exponent with exponent < 0.
+  bignum_assign_uint16(denominator, 1);
+  bignum_shift_left(denominator, -exponent);
+
+  if (need_boundary_deltas) {
+    // Introduce a common denominator so that the deltas to the boundaries are
+    // integers.
+    bignum_shift_left(numerator, 1);
+    bignum_shift_left(denominator, 1);
+    // With this shift the boundaries have their correct value, since
+    // delta_plus = 10^-estimated_power, and
+    // delta_minus = 10^-estimated_power.
+    // These assignments have been done earlier.
+    // The adjustments if f == 2^p-1 (lower boundary is closer) are done later.
+  }
+}
+
+
+// Let v = significand * 2^exponent.
+// Computes v / 10^estimated_power exactly, as a ratio of two bignums, numerator
+// and denominator. The functions GenerateShortestDigits and
+// GenerateCountedDigits will then convert this ratio to its decimal
+// representation d, with the required accuracy.
+// Then d * 10^estimated_power is the representation of v.
+// (Note: the fraction and the estimated_power might get adjusted before
+// generating the decimal representation.)
+//
+// The initial start values consist of:
+//  - a scaled numerator: s.t. numerator/denominator == v / 10^estimated_power.
+//  - a scaled (common) denominator.
+//  optionally (used by GenerateShortestDigits to decide if it has the shortest
+//  decimal converting back to v):
+//  - v - m-: the distance to the lower boundary.
+//  - m+ - v: the distance to the upper boundary.
+//
+// v, m+, m-, and therefore v - m- and m+ - v all share the same denominator.
+//
+// Let ep == estimated_power, then the returned values will satisfy:
+//  v / 10^ep = numerator / denominator.
+//  v's boundarys m- and m+:
+//    m- / 10^ep == v / 10^ep - delta_minus / denominator
+//    m+ / 10^ep == v / 10^ep + delta_plus / denominator
+//  Or in other words:
+//    m- == v - delta_minus * 10^ep / denominator;
+//    m+ == v + delta_plus * 10^ep / denominator;
+//
+// Since 10^(k-1) <= v < 10^k    (with k == estimated_power)
+//  or       10^k <= v < 10^(k+1)
+//  we then have 0.1 <= numerator/denominator < 1
+//           or    1 <= numerator/denominator < 10
+//
+// It is then easy to kickstart the digit-generation routine.
+//
+// The boundary-deltas are only filled if the mode equals BIGNUM_DTOA_SHORTEST
+// or BIGNUM_DTOA_SHORTEST_SINGLE.
+
+static void InitialScaledStartValues(uint64_t significand,
+                                     int exponent,
+                                     bool lower_boundary_is_closer,
+                                     int estimated_power,
+                                     bool need_boundary_deltas,
+                                     bignum* numerator,
+                                     bignum* denominator,
+                                     bignum* delta_minus,
+                                     bignum* delta_plus) {
+  if (exponent >= 0) {
+    InitialScaledStartValuesPositiveExponent(
+        significand, exponent, estimated_power, need_boundary_deltas,
+        numerator, denominator, delta_minus, delta_plus);
+  } else if (estimated_power >= 0) {
+    InitialScaledStartValuesNegativeExponentPositivePower(
+        significand, exponent, estimated_power, need_boundary_deltas,
+        numerator, denominator, delta_minus, delta_plus);
+  } else {
+    InitialScaledStartValuesNegativeExponentNegativePower(
+        significand, exponent, estimated_power, need_boundary_deltas,
+        numerator, denominator, delta_minus, delta_plus);
+  }
+
+  if (need_boundary_deltas && lower_boundary_is_closer) {
+    // The lower boundary is closer at half the distance of "normal" numbers.
+    // Increase the common denominator and adapt all but the delta_minus.
+    bignum_shift_left(denominator, 1);  // *2
+    bignum_shift_left(numerator, 1);    // *2
+    bignum_shift_left(delta_plus, 1);   // *2
+  }
+}
+
+
+// This routine multiplies numerator/denominator so that its values lies in the
+// range 1-10. That is after a call to this function we have:
+//    1 <= (numerator + delta_plus) /denominator < 10.
+// Let numerator the input before modification and numerator' the argument
+// after modification, then the output-parameter decimal_point is such that
+//  numerator / denominator * 10^estimated_power ==
+//    numerator' / denominator' * 10^(decimal_point - 1)
+// In some cases estimated_power was too low, and this is already the case. We
+// then simply adjust the power so that 10^(k-1) <= v < 10^k (with k ==
+// estimated_power) but do not touch the numerator or denominator.
+// Otherwise the routine multiplies the numerator and the deltas by 10.
+static void FixupMultiply10(int estimated_power, bool is_even,
+                            int* decimal_point,
+                            bignum* numerator, bignum* denominator,
+                            bignum* delta_minus, bignum* delta_plus) {
+  bool in_range;
+  if (is_even) {
+    // For IEEE doubles half-way cases (in decimal system numbers ending with 5)
+    // are rounded to the closest floating-point number with even significand.
+    in_range = bignum_plus_compare(*numerator, *delta_plus, *denominator) >= 0;
+  } else {
+    in_range = bignum_plus_compare(*numerator, *delta_plus, *denominator) > 0;
+  }
+  if (in_range) {
+    // Since numerator + delta_plus >= denominator we already have
+    // 1 <= numerator/denominator < 10. Simply update the estimated_power.
+    *decimal_point = estimated_power + 1;
+  } else {
+    *decimal_point = estimated_power;
+    bignum_times_10(numerator);
+    if (bignum_equal(*delta_minus, *delta_plus)) {
+      bignum_times_10(delta_minus);
+      bignum_assign_bignum(delta_plus, *delta_minus);
+    } else {
+      bignum_times_10(delta_minus);
+      bignum_times_10(delta_plus);
+    }
+  }
+}

--- a/src/bignum_dtoa.h
+++ b/src/bignum_dtoa.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) 2010, the V8 project authors.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef OCAML_DTOA_BIGNUM_DTOA_H_
+#define OCAML_DTOA_BIGNUM_DTOA_H_
+
+#include "utils.h"
+
+typedef enum {
+  // Return the shortest correct representation.
+  // For example the output of 0.299999999999999988897 is (the less accurate but
+  // correct) 0.3.
+  BIGNUM_DTOA_SHORTEST,
+  // Same as BIGNUM_DTOA_SHORTEST but for single-precision floats.
+  BIGNUM_DTOA_SHORTEST_SINGLE,
+  // Return a fixed number of digits after the decimal point.
+  // For instance fixed(0.1, 4) becomes 0.1000
+  // If the input number is big, the output will be big.
+  BIGNUM_DTOA_FIXED,
+  // Return a fixed number of digits, no matter what the exponent is.
+  BIGNUM_DTOA_PRECISION
+} BignumDtoaMode;
+
+// Converts the given double 'v' to ascii.
+// The result should be interpreted as buffer * 10^(point-length).
+// The buffer will be null-terminated.
+//
+// The input v must be > 0 and different from NaN, and Infinity.
+//
+// The output depends on the given mode:
+//  - SHORTEST: produce the least amount of digits for which the internal
+//   identity requirement is still satisfied. If the digits are printed
+//   (together with the correct exponent) then reading this number will give
+//   'v' again. The buffer will choose the representation that is closest to
+//   'v'. If there are two at the same distance, than the number is round up.
+//   In this mode the 'requested_digits' parameter is ignored.
+//  - FIXED: produces digits necessary to print a given number with
+//   'requested_digits' digits after the decimal point. The produced digits
+//   might be too short in which case the caller has to fill the gaps with '0's.
+//   Example: toFixed(0.001, 5) is allowed to return buffer="1", point=-2.
+//   Halfway cases are rounded up. The call toFixed(0.15, 2) thus returns
+//     buffer="2", point=0.
+//   Note: the length of the returned buffer has no meaning wrt the significance
+//   of its digits. That is, just because it contains '0's does not mean that
+//   any other digit would not satisfy the internal identity requirement.
+//  - PRECISION: produces 'requested_digits' where the first digit is not '0'.
+//   Even though the length of produced digits usually equals
+//   'requested_digits', the function is allowed to return fewer digits, in
+//   which case the caller has to fill the missing digits with '0's.
+//   Halfway cases are again rounded up.
+// 'bignum_dtoa' expects the given buffer to be big enough to hold all digits
+// and a terminating null-character.
+void bignum_dtoa(
+  double v,
+  BignumDtoaMode mode,
+  int requested_digits,
+  char* buffer,
+  int* length,
+  int* decimal_point
+);
+
+#endif  // OCAML_DTOA_BIGNUM_DTOA_H_

--- a/src/fast_dtoa.c
+++ b/src/fast_dtoa.c
@@ -344,8 +344,7 @@ static bool grisu3(double v,
     double_normalized_boundaries(v, &boundary_minus, &boundary_plus);
   } else {
     ASSERT(mode == FAST_DTOA_SHORTEST_SINGLE);
-    // TODO: support singles
-    // float single_v = (float)(v);
+    float single_v = (float)(v);
     // Single(single_v).NormalizedBoundaries(&boundary_minus, &boundary_plus);
   }
   ASSERT(boundary_plus.e == w.e);

--- a/src/ieee.h
+++ b/src/ieee.h
@@ -16,7 +16,7 @@
 extern const uint64_t kSignMask;
 extern const uint64_t kExponentMask;
 extern const uint64_t kSignificandMask;
-extern const uint64_t kHiddenBit;
+extern const uint64_t kDoubleHiddenBit;
 extern const int kPhysicalSignificandSize;
 extern const int kDoubleSignificandSize;
 
@@ -37,5 +37,9 @@ diy_fp double_as_normalized_diy_fp(double d);
 void double_normalized_boundaries(
   double d, diy_fp* out_m_minus, diy_fp* out_m_plus
 );
+
+int double_exponent(double d);
+uint64_t double_significand(double d);
+bool double_lower_boundary_is_closer(double d);
 
 #endif  // OCAML_DTOA_IEEE_H_

--- a/src/libdtoa.clib
+++ b/src/libdtoa.clib
@@ -1,4 +1,6 @@
+bignum.o
 cached_powers.o
 diy_fp.o
+dtoa_stubs.o
 ieee.o
-dtoa_stubs.o fast_dtoa.o
+fast_dtoa.o

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,25 @@
 #define ASSERT(condition)         \
     assert(condition);
 #endif
+#ifndef UNIMPLEMENTED
+#define UNIMPLEMENTED() (abort())
+#endif
+// #ifndef DOUBLE_CONVERSION_NO_RETURN
+// #ifdef _MSC_VER
+// #define DOUBLE_CONVERSION_NO_RETURN __declspec(noreturn)
+// #else
+// #define DOUBLE_CONVERSION_NO_RETURN __attribute__((noreturn))
+// #endif
+// #endif
+#ifndef UNREACHABLE
+// #ifdef _MSC_VER
+// void DOUBLE_CONVERSION_NO_RETURN abort_noreturn();
+// inline void abort_noreturn() { abort(); }
+// #define UNREACHABLE()   (abort_noreturn())
+// #else
+#define UNREACHABLE()   (abort())
+// #endif
+#endif
 
 // The following macro works on both 32 and 64-bit platforms.
 // Usage: instead of writing 0x1234567890123456

--- a/test/ecma_test.ml
+++ b/test/ecma_test.ml
@@ -52,6 +52,9 @@ let tests = "ecma_string_of_float" >::: [
     eq                     "NaN" (ecma_string_of_float Pervasives.nan);
     eq                "Infinity" (ecma_string_of_float Pervasives.infinity);
     eq               "-Infinity" (ecma_string_of_float Pervasives.neg_infinity);
+
+    (* grisu3 fails, uses bignum *)
+    eq             "0.000035689" (ecma_string_of_float 0.000035689);
   end;
 
   "round_trip" >:: begin fun ctxt ->

--- a/test/g_fmt_test.ml
+++ b/test/g_fmt_test.ml
@@ -52,6 +52,9 @@ let tests = "g_fmt" >::: [
     eq                     "NaN" (g_fmt Pervasives.nan);
     eq                "Infinity" (g_fmt Pervasives.infinity);
     eq               "-Infinity" (g_fmt Pervasives.neg_infinity);
+
+    (* grisu3 fails, uses bignum *)
+    eq               "3.5689e-5" (g_fmt 0.000035689);
   end;
 
   "round_trip" >:: begin fun ctxt ->

--- a/test/shortest_test.ml
+++ b/test/shortest_test.ml
@@ -56,6 +56,9 @@ let tests = "shortest_string_of_float" >::: [
     eq                    "NaN" (shortest_string_of_float Pervasives.nan);
     eq               "Infinity" (shortest_string_of_float Pervasives.infinity);
     eq              "-Infinity" (shortest_string_of_float Pervasives.neg_infinity);
+
+    (* grisu3 fails, uses bignum *)
+    eq               "35689e-9" (shortest_string_of_float 0.000035689);
   end;
 
   "round_trip" >:: begin fun ctxt ->


### PR DESCRIPTION
this diff ports [double-conversion](https://github.com/google/double-conversion)'s `BignumDtoa` implementation from C++ to C.

see the original source (as of commit 23cac04d45f17ff27c9c0224aa4e0610b1a4f540):

https://github.com/google/double-conversion/blob/23cac04d45f17ff27c9c0224aa4e0610b1a4f540/double-conversion/bignum-dtoa.cc
https://github.com/google/double-conversion/blob/23cac04d45f17ff27c9c0224aa4e0610b1a4f540/double-conversion/bignum-dtoa.h
https://github.com/google/double-conversion/blob/23cac04d45f17ff27c9c0224aa4e0610b1a4f540/double-conversion/bignum.cc
https://github.com/google/double-conversion/blob/23cac04d45f17ff27c9c0224aa4e0610b1a4f540/double-conversion/bignum.h