### PR TITLE
Fix compilation under Windows

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name dtoa)

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -450,7 +450,7 @@ void bignum_multiply_by_power_of_ten(bignum* num, int exponent) {
 
 
 void bignum_times_10(bignum* num) {
-  return bignum_multiply_by_uint32(num, 10);
+  bignum_multiply_by_uint32(num, 10);
 }
 
 

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,21 @@
+(rule
+ (enabled_if (= %{ocaml-config:ccomp_type} cc))
+ (action
+  (with-stdout-to c_flags.sexp
+   (echo "(-std=c99 -g -Wall -Wshadow -Werror -Wextra -Wshadow -Wno-unused-parameter)"))))
+
+(rule
+ (enabled_if (<> %{ocaml-config:ccomp_type} cc))
+ (action
+  (with-stdout-to c_flags.sexp
+   (echo "()"))))
+
 (library
  (name dtoa)
  (public_name dtoa)
- (c_names bignum bignum_dtoa cached_powers diy_fp dtoa_stubs ieee fast_dtoa)
- (c_flags -std=c99 -g -Wall -Wshadow -Werror -Wextra -Wshadow
-   -Wno-unused-parameter)
+ (foreign_stubs
+  (language c)
+  (names bignum bignum_dtoa cached_powers diy_fp dtoa_stubs ieee fast_dtoa)
+  (flags (:include c_flags.sexp)))
  (js_of_ocaml
   (javascript_files ../js/dtoa_stubs.js)))

--- a/test/dune
+++ b/test/dune
@@ -2,8 +2,8 @@
  (name test)
  (libraries dtoa oUnit))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps
   (:< test.exe))
  (action


### PR DESCRIPTION
Hello, thank you for your project. This PR contains two trivial fixes so that the project can be built under Windows (MSVC).

- Do not pass gcc-style compiler flags under Windows, and
- Remove a mistaken `return` in a void-returning function in the C code.

The Dune lang version needs to be bumped in order to be able to pass flags conditionally for the first point.

Thanks!