### PR TITLE
Fix ecma assert

### DIFF
--- a/src/dtoa_stubs.c
+++ b/src/dtoa_stubs.c
@@ -260,7 +260,7 @@ static int grisu3_g_fmt(double v, char *dst) {
 
 CAMLprim value flow_shortest_string_of_float(value num) {
   CAMLparam1(num);
-  char str[32]; // the max length is probably 18, but better safe than sorry
+  char str[32]; // the max length is probably 24, but better safe than sorry
   int len = shortest_dtoa(Double_val(num), str, -3, 3);
   assert(len > 0 && len < 25);
   CAMLreturn(caml_copy_string(str));
@@ -268,15 +268,15 @@ CAMLprim value flow_shortest_string_of_float(value num) {
 
 CAMLprim value flow_ecma_string_of_float(value num) {
   CAMLparam1(num);
-  char str[32]; // the max length is probably 18, but better safe than sorry
+  char str[32]; // the max length is probably 25 (ECMAScript 6.1.6.1.20), but better safe than sorry
   int len = ecma_dtoa(Double_val(num), str);
-  assert(len > 0 && len < 25);
+  assert(len > 0 && len <= 25);
   CAMLreturn(caml_copy_string(str));
 }
 
 CAMLprim value flow_g_fmt(value num) {
   CAMLparam1(num);
-  char str[32]; // the max length is probably 18, but better safe than sorry
+  char str[32]; // the max length is probably 24, but better safe than sorry
   int len = grisu3_g_fmt(Double_val(num), str);
   assert(len > 0 && len < 25);
   CAMLreturn(caml_copy_string(str));


### PR DESCRIPTION
Hello,

The max length of an ECMAScript float string representation depends on the specifications [6.1.6.1.20](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-tostring), they are respectively[1] 22, 19, 25 and 24 for 6.a, 6.b, 6.c and 7. As we can see in the case 6.c they can be as long as 25, so the assert in the case of `ecma_string_of_float` is off by one.

Example of an ECMAScript float of length 25: -0.0000013475801431957922

[1] details:

6.a. minus + max_n = 1 + 21 = 22
6.b. minus + max_k + dot = 1 + 17 + 1 = 19
6.c. minus + zero + dot + -min_n + max_k = 1 + 1 + 1 + 5 + 17 = 25
7.   minus + max_k + dot + e + sign + exponent = 1 + 17 + 1 + 1 + 1 + 3 = 24