### PR TITLE
dtoa_stubs.js: rename caml_new_string to caml_string_of_jsbytes to avoid deprecation warning

### DIFF
--- a/js/dtoa_stubs.js
+++ b/js/dtoa_stubs.js
@@ -6,21 +6,21 @@
  */
 
 //Provides: flow_shortest_string_of_float const
-//Requires: caml_js_from_float, caml_new_string
+//Requires: caml_js_from_float, caml_string_of_jsbytes
 function flow_shortest_string_of_float(num) {
   // TODO: shorten string (drop +, leading 0, shift ., etc)
-  return caml_new_string(caml_js_from_float(num).toString());
+  return caml_string_of_jsbytes(caml_js_from_float(num).toString());
 }
 
 //Provides: flow_ecma_string_of_float const
-//Requires: caml_js_from_float, caml_new_string
+//Requires: caml_js_from_float, caml_string_of_jsbytes
 function flow_ecma_string_of_float(num) {
-  return caml_new_string(caml_js_from_float(num).toString());
+  return caml_string_of_jsbytes(caml_js_from_float(num).toString());
 }
 
 //Provides: flow_g_fmt const
-//Requires: caml_js_from_float, caml_new_string
+//Requires: caml_js_from_float, caml_string_of_jsbytes
 function flow_g_fmt(num) {
   // TODO: shorten string
-  return caml_new_string(caml_js_from_float(num).toString());
+  return caml_string_of_jsbytes(caml_js_from_float(num).toString());
 }


### PR DESCRIPTION
Recent versions of `js_of_ocaml` have deprecated the primitive `caml_new_string` (see 5.9.1 entry in https://github.com/ocsigen/js_of_ocaml/blob/master/CHANGES.md), resulting in warnings like:

![image](https://github.com/user-attachments/assets/bc01aa13-e2a5-41f1-b85d-8e5e5e638435)

This PR switches to the new name for the primitive to avoid the warning.